### PR TITLE
Add selector component

### DIFF
--- a/src/shared/ui/selector/index.tsx
+++ b/src/shared/ui/selector/index.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import { Input as MantineInput, Select as MantineSelect, SelectProps as MantineSelectProps } from '@mantine/core';
+
+type SelectorValue = string | null;
+
+type SelectorProps = Omit<MantineSelectProps, 'data' | 'value' | 'defaultValue' | 'onChange'> & {
+  data: { value: string; label: string }[];
+  value?: SelectorValue;
+  defaultValue?: SelectorValue;
+  onChange?: (value: SelectorValue) => void;
+};
+
+const Selector: React.FC<SelectorProps> = ({ data, value, defaultValue, rightSection, onChange, ...props }) => {
+  const handleOnChange: MantineSelectProps['onChange'] = (val) => {
+    onChange?.(val ?? null);
+  };
+
+  const hasValue = value !== null && value !== undefined && value !== '';
+
+  const defaultRightSection = (
+    <MantineInput.ClearButton
+      onClick={() => onChange?.(null)}
+      style={{
+        opacity: hasValue ? 1 : 0,
+        pointerEvents: hasValue ? 'auto' : 'none',
+      }}
+    />
+  );
+
+  return (
+    <MantineSelect
+      data={data}
+      value={value ?? undefined}
+      defaultValue={defaultValue ?? undefined}
+      onChange={handleOnChange}
+      rightSection={rightSection ?? defaultRightSection}
+      {...props}
+    />
+  );
+};
+
+export default Selector;

--- a/src/shared/ui/selector/selector.stories.tsx
+++ b/src/shared/ui/selector/selector.stories.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+
+import 'app/globals.css';
+
+import { MantineProvider } from '@mantine/core';
+import type { Meta, StoryFn } from '@storybook/nextjs-vite';
+
+import Selector from './index';
+
+import '@mantine/core/styles.css';
+
+const meta: Meta<typeof Selector> = {
+  title: 'shared/ui/selector',
+  component: Selector,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <MantineProvider>
+        <Story />
+      </MantineProvider>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryFn<typeof Selector>;
+
+const options = [
+  { value: 'first', label: 'First option' },
+  { value: 'second', label: 'Second option' },
+  { value: 'third', label: 'Third option' },
+];
+
+export const Controlled: Story = (args) => {
+  const [value, setValue] = useState<string | null>(args.value ?? null);
+
+  useEffect(() => {
+    if (typeof args.value === 'string' || args.value === null) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setValue(args.value);
+    }
+  }, [args.value]);
+
+  return <Selector {...args} value={value} onChange={setValue} data={options} />;
+};
+
+Controlled.args = {
+  label: 'Controlled selector',
+  value: 'second',
+};
+
+export const Uncontrolled: Story = (args) => <Selector {...args} data={options} />;
+
+Uncontrolled.args = {
+  label: 'Uncontrolled selector',
+  defaultValue: 'first',
+};
+
+export const WithError: Story = (args) => <Selector {...args} data={options} />;
+
+WithError.args = {
+  label: 'Selector with error',
+  error: 'Error message',
+};
+
+export const Disabled: Story = (args) => <Selector {...args} data={options} />;
+
+Disabled.args = {
+  label: 'Disabled selector',
+  disabled: true,
+};


### PR DESCRIPTION
## Summary
- add shared Selector component wrapping Mantine Select with clear control and null-safe change handling
- add Storybook stories covering controlled, uncontrolled, error, and disabled selector states

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b2f86dd64832cacce237f19d1d642)